### PR TITLE
Swipe to dismiss interactive transition

### DIFF
--- a/Example/ImageSlideshow/ViewController.swift
+++ b/Example/ImageSlideshow/ViewController.swift
@@ -54,7 +54,7 @@ class ViewController: UIViewController {
         
         ctr.initialPage = slideshow.scrollViewPage
         ctr.inputs = slideshow.images
-        self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow);
+        self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow, slideshowController: ctr)
         ctr.transitioningDelegate = self.transitionDelegate!
         self.presentViewController(ctr, animated: true, completion: nil)
     }

--- a/Example/ImageSlideshow/ViewController.swift
+++ b/Example/ImageSlideshow/ViewController.swift
@@ -55,7 +55,9 @@ class ViewController: UIViewController {
         ctr.initialPage = slideshow.scrollViewPage
         ctr.inputs = slideshow.images
         self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow, slideshowController: ctr)
-        ctr.transitioningDelegate = self.transitionDelegate!
+        // Uncomment if you want disable the slide-to-dismiss feature
+        // self.transitionDelegate?.slideToDismissEnabled = false
+        ctr.transitioningDelegate = self.transitionDelegate
         self.presentViewController(ctr, animated: true, completion: nil)
     }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,22 +1,22 @@
 PODS:
-  - Alamofire (3.3.0)
+  - Alamofire (3.3.1)
   - AlamofireImage (2.4.0):
     - Alamofire (~> 3.3)
-  - ImageSlideshow/Alamofire (0.3.1):
+  - ImageSlideshow/Alamofire (0.4.0):
     - AlamofireImage (~> 2.0)
     - ImageSlideshow/Core
-  - ImageSlideshow/Core (0.3.1)
+  - ImageSlideshow/Core (0.4.0)
 
 DEPENDENCIES:
   - ImageSlideshow/Alamofire (from `../`)
 
 EXTERNAL SOURCES:
   ImageSlideshow:
-    :path: "../"
+    :path: ../
 
 SPEC CHECKSUMS:
-  Alamofire: 9054db4a1b1ca9e363223183e01cea380159a27c
+  Alamofire: 369bc67b6f5ac33ded3648d7bd21c5bfb91c2ecc
   AlamofireImage: 87408b652e0f5ae5fe364035f15aea8b9b24c77e
-  ImageSlideshow: d421a31970f81a365748242d1f5808659a6a712e
+  ImageSlideshow: 0d3632bc0c2b4d3fff24a49ce4d3022af8238b03
 
 COCOAPODS: 0.39.0

--- a/Pod/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/Pod/Classes/Core/FullScreenSlideshowViewController.swift
@@ -33,6 +33,8 @@ public class FullScreenSlideshowViewController: UIViewController {
         }
     }
     
+    private var isInit = true
+    
     override public func viewDidLoad() {
         super.viewDidLoad()
         
@@ -63,7 +65,10 @@ public class FullScreenSlideshowViewController: UIViewController {
     override public func viewWillAppear(animated: Bool) {
         super.viewWillAppear(animated)
         
-        slideshow.setScrollViewPage(self.initialPage, animated: false)
+        if isInit {
+            isInit = false
+            slideshow.setScrollViewPage(self.initialPage, animated: false)
+        }
     }
     
     func close() {

--- a/Pod/Classes/Core/ImageSlideshow.swift
+++ b/Pod/Classes/Core/ImageSlideshow.swift
@@ -211,6 +211,7 @@ public class ImageSlideshow: UIView, UIScrollViewDelegate {
     }
     
     func slideshowTick(timer: NSTimer) {
+        
         let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
         var nextPage = page + 1
         
@@ -246,6 +247,17 @@ public class ImageSlideshow: UIView, UIScrollViewDelegate {
         } else {
             currentPage = page
         }
+    }
+    
+    /// Stops slideshow timer
+    public func pauseTimerIfNeeded() {
+        slideshowTimer?.invalidate()
+        slideshowTimer = nil
+    }
+    
+    /// Restarts slideshow timer
+    public func unpauseTimerIfNeeded() {
+        setTimerIfNeeded()
     }
     
     // MARK: UIScrollViewDelegate

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -31,7 +31,7 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
     
     func handleSwipe(gesture: UIPanGestureRecognizer) {
         let percent = min(max(gesture.translationInView(gesture.view!).y / 200.0, 0.0), 1.0)
-        print(percent)
+        
         if gesture.state == .Began {
             interactionController = UIPercentDrivenInteractiveTransition()
             referenceSlideshowController?.dismissViewControllerAnimated(true, completion: nil)
@@ -40,7 +40,12 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
         } else if gesture.state == .Ended || gesture.state == .Cancelled || gesture.state == .Failed {
             
             if percent > 0.5 {
+                if let pageSelected = referenceSlideshowController?.pageSelected, let slideshow = referenceSlideshowController?.slideshow {
+                    pageSelected(page: slideshow.scrollViewPage)
+                }
+                
                 interactionController?.finishInteractiveTransition()
+                
             } else {
                 interactionController?.cancelInteractiveTransition()
             }

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -77,6 +77,10 @@ extension ZoomAnimatedTransitioningDelegate: UIGestureRecognizerDelegate {
             return false
         }
         
+        if let currentItem = referenceSlideshowController?.slideshow.currentSlideshowItem where currentItem.isZoomed() {
+            return false
+        }
+        
         let translation = panGestureRecognizer.translationInView(panGestureRecognizer.view!).y
         // If panning from bottom to top transition must not begin
         if translation < 0 {

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -202,7 +202,7 @@ class ZoomAnimatedTransitioning: NSObject, UIViewControllerAnimatedTransitioning
         
         let duration: NSTimeInterval = self.transitionDuration(transitionContext)
         
-        UIView.animateWithDuration(duration, delay: 0, options: UIViewAnimationOptions.CurveLinear, animations: {
+        UIView.animateWithDuration(duration, delay: 0, options: UIViewAnimationOptions.CurveEaseInOut, animations: {
             toViewController.view.alpha = 1
             transitionView.frame = transitionViewFinalFrame
             }, completion: {(finished: Bool) in

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -16,6 +16,9 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
     var gestureRecognizer: UIPanGestureRecognizer!
     private var interactionController: UIPercentDrivenInteractiveTransition?
     
+    /// Enables or disables swipe-to-dismiss
+    public var slideToDismissEnabled: Bool = true
+    
     public init(slideshowView: ImageSlideshow, slideshowController: FullScreenSlideshowViewController) {
         self.referenceSlideshowView = slideshowView
         self.referenceSlideshowController = slideshowController
@@ -74,6 +77,10 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
 extension ZoomAnimatedTransitioningDelegate: UIGestureRecognizerDelegate {
     public func gestureRecognizerShouldBegin(gestureRecognizer: UIGestureRecognizer) -> Bool {
         guard let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer else {
+            return false
+        }
+        
+        if !slideToDismissEnabled {
             return false
         }
         

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -33,7 +33,7 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
     }
     
     func handleSwipe(gesture: UIPanGestureRecognizer) {
-        let percent = min(max(gesture.translationInView(gesture.view!).y / 200.0, 0.0), 1.0)
+        let percent = min(max(fabs(gesture.translationInView(gesture.view!).y) / 200.0, 0.0), 1.0)
         
         if gesture.state == .Began {
             interactionController = UIPercentDrivenInteractiveTransition()
@@ -85,12 +85,6 @@ extension ZoomAnimatedTransitioningDelegate: UIGestureRecognizerDelegate {
         }
         
         if let currentItem = referenceSlideshowController?.slideshow.currentSlideshowItem where currentItem.isZoomed() {
-            return false
-        }
-        
-        let translation = panGestureRecognizer.translationInView(panGestureRecognizer.view!).y
-        // If panning from bottom to top transition must not begin
-        if translation < 0 {
             return false
         }
         

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -110,6 +110,10 @@ class ZoomAnimatedTransitioning: NSObject, UIViewControllerAnimatedTransitioning
     }
     
     func animateZoomInTransition(transitionContext: UIViewControllerContextTransitioning) {
+        
+        // Pauses slideshow
+        self.referenceSlideshowView.pauseTimerIfNeeded()
+        
         let fromViewController: UIViewController = transitionContext.viewControllerForKey(UITransitionContextFromViewControllerKey)!
         let toViewController: FullScreenSlideshowViewController = transitionContext.viewControllerForKey(UITransitionContextToViewControllerKey) as! FullScreenSlideshowViewController
         toViewController.view.frame = transitionContext.finalFrameForViewController(toViewController)
@@ -203,6 +207,8 @@ class ZoomAnimatedTransitioning: NSObject, UIViewControllerAnimatedTransitioning
                     self.referenceSlideshowView.alpha = 1
                     fromViewController.view.removeFromSuperview()
                     UIApplication.sharedApplication().keyWindow?.removeGestureRecognizer(self.parent.gestureRecognizer)
+                    // Unpauses slideshow
+                    self.referenceSlideshowView.unpauseTimerIfNeeded()
                 } else {
                     fromViewController.view.hidden = false
                     self.referenceSlideshowView.alpha = 0

--- a/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/Pod/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -30,8 +30,8 @@ public class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransi
     }
     
     func handleSwipe(gesture: UIPanGestureRecognizer) {
-        let percent = gesture.translationInView(gesture.view!).y / 200.0
-        
+        let percent = min(max(gesture.translationInView(gesture.view!).y / 200.0, 0.0), 1.0)
+        print(percent)
         if gesture.state == .Began {
             interactionController = UIPercentDrivenInteractiveTransition()
             referenceSlideshowController?.dismissViewControllerAnimated(true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -113,8 +113,8 @@ func click() {
   ctr.initialPage = slideshow.scrollViewPage
   // set the inputs
   ctr.inputs = slideshow.images
-  self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow);
-  ctr.transitioningDelegate = self.transitionDelegate!
+  self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow, slideshowController: ctr)
+  ctr.transitioningDelegate = self.transitionDelegate
   self.presentViewController(ctr, animated: true, completion: nil)
 }
 ```


### PR DESCRIPTION
This pull request contains swipe-to-dismiss feature and few tweaks:
- pausing slideshow timer when transition begin (in order to avoid scroll bug during transition)
- changes timing function from Linear to EaseInOut (it looks much better)

![slideshow](https://cloud.githubusercontent.com/assets/4762172/14580588/1304f3f0-03d2-11e6-87ee-74ee90c85f29.gif)

**This pull request changes API of ZoomAnimatedTransitioningDelegate**
from
```swift
public init(slideshowView: ImageSlideshow)
```
to 
```swift
public init(slideshowView: ImageSlideshow, slideshowController: FullScreenSlideshowViewController)
```