### PR TITLE
Remove delegate's slideshowController argument from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ func click() {
   ctr.initialPage = slideshow.scrollViewPage
   // set the inputs
   ctr.inputs = slideshow.images
-  self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow, slideshowController: ctr)
+  self.transitionDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: slideshow)
   ctr.transitioningDelegate = self.transitionDelegate
   self.presentViewController(ctr, animated: true, completion: nil)
 }


### PR DESCRIPTION
Updating README's example, `ZoomAnimatedTransitioningDelegate` no longer requires `slideshowController` as argument.