### PR TITLE
Rounding error fix for page calculation

### DIFF
--- a/Pod/Classes/Core/ImageSlideshow.swift
+++ b/Pod/Classes/Core/ImageSlideshow.swift
@@ -357,8 +357,8 @@ extension ImageSlideshow: UIScrollViewDelegate {
         setTimerIfNeeded()
     }
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
-        let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
-        setCurrentPageForScrollViewPage(page);
+        let page = Int(scrollView.contentOffset.x) / Int(scrollView.frame.size.width)
+        setCurrentPageForScrollViewPage(page)
     }
     
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {


### PR DESCRIPTION
There was an error in the calculation of the page based on the scrollview.
As long as you have a full width slideshow everything is fine, but when your slideshow frame is smaller than the screen you can have page calculation errors due to rounding of CGFloat values, resulting in page counting as for example 1,1,3,3,5,6,6,....
Note: Swift CGFloat operations are not the same as ObjC CGFloat ones. The original code did probably work for ObjC projects, but in Swift you must alter some calculations.