### PR TITLE
Fix for black image when using fullscreen zoom

### DIFF
--- a/Pod/Classes/Core/ImageSlideshow.swift
+++ b/Pod/Classes/Core/ImageSlideshow.swift
@@ -333,6 +333,10 @@ open class ImageSlideshow: UIView {
     open func presentFullScreenController(from controller:UIViewController) -> FullScreenSlideshowViewController {
         let fullscreen = FullScreenSlideshowViewController()
         fullscreen.pageSelected = {(page: Int) in
+            // Before setting the new page, make sure that the current page image view is made visible again (altered by ZoomAnimator)
+            if let ci = self.currentSlideshowItem {
+                ci.imageView.alpha = 1.0
+            }
             self.setCurrentPage(page, animated: false)
         }
 


### PR DESCRIPTION
This fixes a bug with the fullscreen animation.
Steps to reproduce _before_ this fix is applied:
1) In the Slideshow navigate to any image. In this example to image 1
2) Zoom to fullscreen
3) In fullscreen navigate to image 3 (any other than image 1 will do)
4) Close fullscreen and navigate back to image 1
Image 1 will not be shown as the alpha value of its UIImageView is still set to 0.0 by the ZoomAnimator 