### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Behaviour is configurable by those properties:
 
 - ```slideshowInterval``` - in case you want automatic slideshow, set up the interval between sliding to next picture
 - ```zoomEnabled``` - enables zooming
-- ```circular``` - enables circular scrolling
+- ```circular``` - enables circular scrolling. Enabled by default, if you wanna disable it make sure you do it before calling `setImageInputs`
 - ```pageControlPosition``` - configures position of UIPageControll (hidden, inside scroll view or under scroll view)
 - ```contentScaleMode``` - configures the scaling (UIViewContentMode.ScaleAspectFit by default)
 - ```draggingEnabled``` - enables dragging


### PR DESCRIPTION
Setting `circular=false` after `setImageInputs` causes to load the input[1] upon tapping on [0], the array is shifted due this https://github.com/zvonicek/ImageSlideshow/blob/master/ImageSlideshow/Classes/Core/ImageSlideshow.swift#L263

It was a tricky bug to catch but I think it's ok to just update the Readme for now