### PR TITLE
Range check newPage value instead of currentPage

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -303,7 +303,7 @@ open class ImageSlideshow: UIView {
      - parameter animated: true if animate the change
      */
     open func setScrollViewPage(_ newScrollViewPage: Int, animated: Bool) {
-        if scrollViewPage < scrollViewImages.count {
+        if newScrollViewPage < scrollViewImages.count {
             self.scrollView.scrollRectToVisible(CGRect(x: scrollView.frame.size.width * CGFloat(newScrollViewPage), y: 0, width: scrollView.frame.size.width, height: scrollView.frame.size.height), animated: animated)
             self.setCurrentPageForScrollViewPage(newScrollViewPage)
         }


### PR DESCRIPTION
Hello,

I may be misunderstanding the purpose of this range check but it breaks on the case where I remove the last image in the slideshow (can't set a new page because scrollViewPage is equal to scrollViewImages.count). I can give you a code sample if you want.

Thanks for this library and all your hard work! 😄

-Konrad