### PR TITLE
Small fixes and improvements

### DIFF
--- a/Example/ImageSlideshow.xcodeproj/project.pbxproj
+++ b/Example/ImageSlideshow.xcodeproj/project.pbxproj
@@ -542,7 +542,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = FD45C56C18E7B8EC08371B86 /* Pods-ImageSlideshow_Example.debug.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 5VWB99DS38;
 				INFOPLIST_FILE = ImageSlideshow/Info.plist;
@@ -558,7 +557,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 09417F1351C21E0DCE8667BE /* Pods-ImageSlideshow_Example.release.xcconfig */;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				DEVELOPMENT_TEAM = 5VWB99DS38;
 				INFOPLIST_FILE = ImageSlideshow/Info.plist;

--- a/Example/ImageSlideshow/AppDelegate.swift
+++ b/Example/ImageSlideshow/AppDelegate.swift
@@ -10,9 +10,8 @@ import UIKit
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
-    
-    var window: UIWindow?
 
+    var window: UIWindow?
 
     private func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
         // Override point for customization after application launch.
@@ -41,6 +40,4 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 
-
 }
-

--- a/Example/ImageSlideshow/ViewController.swift
+++ b/Example/ImageSlideshow/ViewController.swift
@@ -12,13 +12,11 @@ import ImageSlideshow
 class ViewController: UIViewController {
 
     open override var supportedInterfaceOrientations: UIInterfaceOrientationMask {
-        get {
-            return .portrait
-        }
+        return .portrait
     }
 
     @IBOutlet var slideshow: ImageSlideshow!
-    var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
+    weak var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
 
     let localSource = [ImageSource(imageString: "img1")!, ImageSource(imageString: "img2")!, ImageSource(imageString: "img3")!, ImageSource(imageString: "img4")!]
     let afNetworkingSource = [AFURLSource(urlString: "https://images.unsplash.com/photo-1432679963831-2dab49187847?w=1080")!, AFURLSource(urlString: "https://images.unsplash.com/photo-1447746249824-4be4e1b76d66?w=1080")!, AFURLSource(urlString: "https://images.unsplash.com/photo-1463595373836-6e0b0a8ee322?w=1080")!]
@@ -29,12 +27,12 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        
+
         slideshow.backgroundColor = UIColor.white
         slideshow.slideshowInterval = 5.0
         slideshow.pageControlPosition = PageControlPosition.underScrollView
-        slideshow.pageControl.currentPageIndicatorTintColor = UIColor.lightGray;
-        slideshow.pageControl.pageIndicatorTintColor = UIColor.black;
+        slideshow.pageControl.currentPageIndicatorTintColor = UIColor.lightGray
+        slideshow.pageControl.pageIndicatorTintColor = UIColor.black
         slideshow.contentScaleMode = UIViewContentMode.scaleAspectFill
 
         // try out other sources such as `afNetworkingSource`, `alamofireSource` or `sdWebImageSource` or `kingfisherSource`
@@ -43,9 +41,8 @@ class ViewController: UIViewController {
         let recognizer = UITapGestureRecognizer(target: self, action: #selector(ViewController.didTap))
         slideshow.addGestureRecognizer(recognizer)
     }
-    
+
     func didTap() {
         slideshow.presentFullScreenController(from: self)
     }
 }
-

--- a/Example/Tests/Tests.swift
+++ b/Example/Tests/Tests.swift
@@ -2,27 +2,27 @@ import UIKit
 import XCTest
 
 class Tests: XCTestCase {
-    
+
     override func setUp() {
         super.setUp()
         // Put setup code here. This method is called before the invocation of each test method in the class.
     }
-    
+
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
-    
+
     func testExample() {
         // This is an example of a functional test case.
         XCTAssert(true, "Pass")
     }
-    
+
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measure() {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }
-    
+
 }

--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 open class FullScreenSlideshowViewController: UIViewController {
-    
+
     open var slideshow: ImageSlideshow = {
         let slideshow = ImageSlideshow()
         slideshow.zoomEnabled = true
@@ -17,7 +17,7 @@ open class FullScreenSlideshowViewController: UIViewController {
         // turns off the timer
         slideshow.slideshowInterval = 0
         slideshow.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
-        
+
         return slideshow
     }()
 
@@ -25,68 +25,68 @@ open class FullScreenSlideshowViewController: UIViewController {
     open var closeButton = UIButton()
 
     /// Closure called on page selection
-    open var pageSelected: ((_ page: Int) -> ())?
-    
+    open var pageSelected: ((_ page: Int) -> Void)?
+
     /// Index of initial image
     open var initialPage: Int = 0
 
     /// Input sources to 
     open var inputs: [InputSource]?
-    
+
     /// Background color
     open var backgroundColor = UIColor.black
-    
+
     /// Enables/disable zoom
     open var zoomEnabled = true {
         didSet {
             slideshow.zoomEnabled = zoomEnabled
         }
     }
-    
+
     fileprivate var isInit = true
-    
+
     override open func viewDidLoad() {
         super.viewDidLoad()
-        
+
         view.backgroundColor = backgroundColor
-        
+
         // slideshow view configuration
         slideshow.frame = view.frame
         slideshow.backgroundColor = backgroundColor
-        
+
         if let inputs = inputs {
             slideshow.setImageInputs(inputs)
         }
-        
+
         slideshow.frame = view.frame
-        view.addSubview(slideshow);
-        
+        view.addSubview(slideshow)
+
         // close button configuration
         closeButton.frame = CGRect(x: 10, y: 20, width: 40, height: 40)
         closeButton.setImage(UIImage(named: "Frameworks/ImageSlideshow.framework/ImageSlideshow.bundle/ic_cross_white@2x"), for: UIControlState())
         closeButton.addTarget(self, action: #selector(FullScreenSlideshowViewController.close), for: UIControlEvents.touchUpInside)
         view.addSubview(closeButton)
     }
-    
-    override open var prefersStatusBarHidden : Bool {
+
+    override open var prefersStatusBarHidden: Bool {
         return true
     }
-    
+
     override open func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        
+
         if isInit {
             isInit = false
             slideshow.setCurrentPage(initialPage, animated: false)
         }
     }
-    
+
     func close() {
         // if pageSelected closure set, send call it with current page
         if let pageSelected = pageSelected {
             pageSelected(slideshow.currentPage)
         }
-        
+
         dismiss(animated: true, completion: nil)
     }
 }

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -133,7 +133,7 @@ open class ImageSlideshow: UIView {
     fileprivate var scrollViewImages = [InputSource]()
 
     /// Transitioning delegate to manage the transition to full screen controller
-    open fileprivate(set) weak var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
+    open fileprivate(set) var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
 
     // MARK: - Life cycle
 

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -19,7 +19,7 @@ public enum PageControlPosition {
     case insideScrollView
     case underScrollView
     case custom(padding: CGFloat)
-    
+
     var bottomPadding: CGFloat {
         switch self {
         case .hidden, .insideScrollView:
@@ -49,9 +49,9 @@ open class ImageSlideshow: UIView {
 
     /// Page Control shown in the slideshow
     open let pageControl = UIPageControl()
-    
+
     // MARK: - State properties
-    
+
     /// Page control position
     open var pageControlPosition = PageControlPosition.insideScrollView {
         didSet {
@@ -59,7 +59,7 @@ open class ImageSlideshow: UIView {
             layoutScrollView()
         }
     }
-    
+
     /// Current page
     open fileprivate(set) var currentPage: Int = 0 {
         didSet {
@@ -73,8 +73,8 @@ open class ImageSlideshow: UIView {
     }
 
     /// Called on each currentPage change
-    open var currentPageChanged: ((_ page: Int) -> ())?
-    
+    open var currentPageChanged: ((_ page: Int) -> Void)?
+
     /// Currenlty displayed slideshow item
     open var currentSlideshowItem: ImageSlideshowItem? {
         if slideshowItems.count > scrollViewPage {
@@ -92,22 +92,22 @@ open class ImageSlideshow: UIView {
 
     /// Image Slideshow Items loaded to slideshow
     open fileprivate(set) var slideshowItems = [ImageSlideshowItem]()
-    
+
     // MARK: - Preferences
-    
+
     /// Enables/disables infinite scrolling between images
     open var circular = true
-    
+
     /// Enables/disables user interactions
     open var draggingEnabled = true {
         didSet {
             self.scrollView.isUserInteractionEnabled = draggingEnabled
         }
     }
-    
+
     /// Enables/disables zoom
     open var zoomEnabled = false
-    
+
     /// Image change interval, zero stops the auto-scrolling
     open var slideshowInterval = 0.0 {
         didSet {
@@ -128,33 +128,33 @@ open class ImageSlideshow: UIView {
             }
         }
     }
-    
+
     fileprivate var slideshowTimer: Timer?
     fileprivate var scrollViewImages = [InputSource]()
 
     /// Transitioning delegate to manage the transition to full screen controller
-    open fileprivate(set) var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
+    open fileprivate(set) weak var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
 
     // MARK: - Life cycle
-    
+
     override public init(frame: CGRect) {
         super.init(frame: frame)
         initialize()
     }
-    
+
     convenience init() {
         self.init(frame: CGRect.zero)
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
         initialize()
     }
-    
+
     fileprivate func initialize() {
         autoresizesSubviews = true
         clipsToBounds = true
-        
+
         // scroll view configuration
         scrollView.frame = CGRect(x: 0, y: 0, width: frame.size.width, height: frame.size.height - 50.0)
         scrollView.delegate = self
@@ -164,14 +164,14 @@ open class ImageSlideshow: UIView {
         scrollView.showsVerticalScrollIndicator = false
         scrollView.autoresizingMask = self.autoresizingMask
         addSubview(scrollView)
-        
+
         addSubview(pageControl)
         pageControl.addTarget(self, action: #selector(pageControlValueChanged), for: .valueChanged)
-        
+
         setTimerIfNeeded()
         layoutScrollView()
     }
-    
+
     override open func layoutSubviews() {
         super.layoutSubviews()
 
@@ -185,26 +185,26 @@ open class ImageSlideshow: UIView {
         }
         pageControl.frame = CGRect(x: 0, y: 0, width: frame.size.width, height: 10)
         pageControl.center = CGPoint(x: frame.size.width / 2, y: frame.size.height - 12.0)
-        
+
         layoutScrollView()
     }
-    
+
     /// updates frame of the scroll view and its inner items
     func layoutScrollView() {
         let scrollViewBottomPadding: CGFloat = pageControlPosition.bottomPadding
         scrollView.frame = CGRect(x: 0, y: 0, width: frame.size.width, height: frame.size.height - scrollViewBottomPadding)
         scrollView.contentSize = CGSize(width: scrollView.frame.size.width * CGFloat(scrollViewImages.count), height: scrollView.frame.size.height)
-        
+
         for (index, view) in self.slideshowItems.enumerated() {
             if !view.zoomInInitially {
                 view.zoomOut()
             }
             view.frame = CGRect(x: scrollView.frame.size.width * CGFloat(index), y: 0, width: scrollView.frame.size.width, height: scrollView.frame.size.height)
         }
-        
+
         setCurrentPage(currentPage, animated: false)
     }
-    
+
     /// reloads scroll view with latest slideshow items
     func reloadScrollView() {
         // remove previous slideshow items
@@ -212,7 +212,7 @@ open class ImageSlideshow: UIView {
             view.removeFromSuperview()
         }
         self.slideshowItems = []
-        
+
         var i = 0
         for image in scrollViewImages {
             let item = ImageSlideshowItem(image: image, zoomEnabled: self.zoomEnabled)
@@ -221,7 +221,7 @@ open class ImageSlideshow: UIView {
             scrollView.addSubview(item)
             i += 1
         }
-        
+
         if circular && (scrollViewImages.count > 1) {
             scrollViewPage = 1
             scrollView.scrollRectToVisible(CGRect(x: scrollView.frame.size.width, y: 0, width: scrollView.frame.size.width, height: scrollView.frame.size.height), animated: false)
@@ -248,7 +248,7 @@ open class ImageSlideshow: UIView {
         }
 
     }
-    
+
     // MARK: - Image setting
 
     /**
@@ -257,12 +257,12 @@ open class ImageSlideshow: UIView {
      */
     open func setImageInputs(_ inputs: [InputSource]) {
         self.images = inputs
-        self.pageControl.numberOfPages = inputs.count;
-        
+        self.pageControl.numberOfPages = inputs.count
+
         // in circular mode we add dummy first and last image to enable smooth scrolling
         if circular && images.count > 1 {
             var scImages = [InputSource]()
-            
+
             if let last = images.last {
                 scImages.append(last)
             }
@@ -270,17 +270,17 @@ open class ImageSlideshow: UIView {
             if let first = images.first {
                 scImages.append(first)
             }
-            
+
             self.scrollViewImages = scImages
         } else {
-            self.scrollViewImages = images;
+            self.scrollViewImages = images
         }
-        
+
         reloadScrollView()
         layoutScrollView()
         setTimerIfNeeded()
     }
-    
+
     // MARK: paging methods
 
     /**
@@ -293,7 +293,7 @@ open class ImageSlideshow: UIView {
         if circular {
             pageOffset += 1
         }
-        
+
         self.setScrollViewPage(pageOffset, animated: animated)
     }
 
@@ -308,24 +308,24 @@ open class ImageSlideshow: UIView {
             self.setCurrentPageForScrollViewPage(newScrollViewPage)
         }
     }
-    
+
     fileprivate func setTimerIfNeeded() {
         if slideshowInterval > 0 && scrollViewImages.count > 1 && slideshowTimer == nil {
             slideshowTimer = Timer.scheduledTimer(timeInterval: slideshowInterval, target: self, selector: #selector(ImageSlideshow.slideshowTick(_:)), userInfo: nil, repeats: true)
         }
     }
-    
+
     func slideshowTick(_ timer: Timer) {
         let page = Int(scrollView.contentOffset.x / scrollView.frame.size.width)
         var nextPage = page + 1
-        
+
         if !circular && page == scrollViewImages.count - 1 {
             nextPage = 0
         }
 
         self.setScrollViewPage(nextPage, animated: true)
     }
-    
+
     fileprivate func setCurrentPageForScrollViewPage(_ page: Int) {
         if scrollViewPage != page {
             // current page has changed, zoom out this image
@@ -333,9 +333,9 @@ open class ImageSlideshow: UIView {
                 slideshowItems[scrollViewPage].zoomOut()
             }
         }
-        
+
         scrollViewPage = page
-        
+
         if circular {
             if page == 0 {
                 // first page contains the last image
@@ -350,13 +350,13 @@ open class ImageSlideshow: UIView {
             currentPage = page
         }
     }
-    
+
     /// Stops slideshow timer
     open func pauseTimerIfNeeded() {
         slideshowTimer?.invalidate()
         slideshowTimer = nil
     }
-    
+
     /// Restarts slideshow timer
     open func unpauseTimerIfNeeded() {
         setTimerIfNeeded()
@@ -368,7 +368,7 @@ open class ImageSlideshow: UIView {
      - returns: FullScreenSlideshowViewController instance
      */
     @discardableResult
-    open func presentFullScreenController(from controller:UIViewController) -> FullScreenSlideshowViewController {
+    open func presentFullScreenController(from controller: UIViewController) -> FullScreenSlideshowViewController {
         let fullscreen = FullScreenSlideshowViewController()
         fullscreen.pageSelected = {(page: Int) in
             self.setCurrentPage(page, animated: false)
@@ -395,22 +395,22 @@ extension ImageSlideshow: UIScrollViewDelegate {
             slideshowTimer?.invalidate()
             slideshowTimer = nil
         }
-        
+
         setTimerIfNeeded()
     }
-    
+
     public func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
         let page = Int(scrollView.contentOffset.x) / Int(scrollView.frame.size.width)
         setCurrentPageForScrollViewPage(page)
     }
-    
+
     public func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if circular {
             let regularContentOffset = scrollView.frame.size.width * CGFloat(images.count)
-            
-            if (scrollView.contentOffset.x >= scrollView.frame.size.width * CGFloat(images.count + 1)) {
+
+            if scrollView.contentOffset.x >= scrollView.frame.size.width * CGFloat(images.count + 1) {
                 scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x - regularContentOffset, y: 0)
-            } else if (scrollView.contentOffset.x < 0) {
+            } else if scrollView.contentOffset.x < 0 {
                 scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x + regularContentOffset, y: 0)
             }
         }

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -23,10 +23,10 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
     /// If set to true image is initially zoomed in
     open var zoomInInitially = false
-    
+
     fileprivate var lastFrame = CGRect.zero
     fileprivate var imageReleased = false
-    
+
     // MARK: - Life cycle
 
     /**
@@ -37,14 +37,14 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
     init(image: InputSource, zoomEnabled: Bool) {
         self.zoomEnabled = zoomEnabled
         self.image = image
-        
+
         super.init(frame: CGRect.null)
 
         imageView.clipsToBounds = true
         imageView.isUserInteractionEnabled = true
-        
+
         setPictoCenter()
-        
+
         // scroll view configuration
         delegate = self
         showsVerticalScrollIndicator = false
@@ -52,41 +52,41 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         addSubview(imageView)
         minimumZoomScale = 1.0
         maximumZoomScale = calculateMaximumScale()
-        
+
         // tap gesture recognizer
         let tapRecognizer = UITapGestureRecognizer(target: self, action: #selector(ImageSlideshowItem.tapZoom))
         tapRecognizer.numberOfTapsRequired = 2
         imageView.addGestureRecognizer(tapRecognizer)
         gestureRecognizer = tapRecognizer
     }
-    
+
     required public init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     override open func layoutSubviews() {
         super.layoutSubviews()
-        
+
         if !zoomEnabled {
-            imageView.frame.size = frame.size;
+            imageView.frame.size = frame.size
         } else if !isZoomed() {
             imageView.frame.size = calculatePictureSize()
             setPictoCenter()
         }
-        
+
         if isFullScreen() {
             clearContentInsets()
         } else {
             setPictoCenter()
         }
-        
+
         // if self.frame was changed and zoomInInitially enabled, zoom in
         if lastFrame != frame && zoomInInitially {
             setZoomScale(maximumZoomScale, animated: false)
         }
-        
+
         lastFrame = self.frame
-        
+
         contentSize = imageView.frame.size
         maximumZoomScale = calculateMaximumScale()
     }
@@ -108,15 +108,15 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
     }
 
     // MARK: - Image zoom & size
-    
+
     func isZoomed() -> Bool {
         return self.zoomScale != self.minimumZoomScale
     }
-    
+
     func zoomOut() {
         self.setZoomScale(minimumZoomScale, animated: false)
     }
-    
+
     func tapZoom() {
         if isZoomed() {
             self.setZoomScale(minimumZoomScale, animated: true)
@@ -124,37 +124,37 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
             self.setZoomScale(maximumZoomScale, animated: true)
         }
     }
-    
+
     fileprivate func screenSize() -> CGSize {
         return CGSize(width: frame.width, height: frame.height)
     }
-    
+
     fileprivate func calculatePictureFrame() {
         let boundsSize: CGSize = bounds.size
         var frameToCenter: CGRect = imageView.frame
-        
+
         if frameToCenter.size.width < boundsSize.width {
             frameToCenter.origin.x = (boundsSize.width - frameToCenter.size.width) / 2
         } else {
             frameToCenter.origin.x = 0
         }
-        
+
         if frameToCenter.size.height < boundsSize.height {
             frameToCenter.origin.y = (boundsSize.height - frameToCenter.size.height) / 2
         } else {
             frameToCenter.origin.y = 0
         }
-        
+
         imageView.frame = frameToCenter
     }
-    
+
     fileprivate func calculatePictureSize() -> CGSize {
         if let image = imageView.image {
             let picSize = image.size
             let picRatio = picSize.width / picSize.height
             let screenRatio = screenSize().width / screenSize().height
-            
-            if (picRatio > screenRatio){
+
+            if picRatio > screenRatio {
                 return CGSize(width: screenSize().width, height: screenSize().width / picSize.width * picSize.height)
             } else {
                 return CGSize(width: screenSize().height / picSize.height * picSize.width, height: screenSize().height)
@@ -163,36 +163,36 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
             return CGSize(width: screenSize().width, height: screenSize().height)
         }
     }
-    
+
     fileprivate func calculateMaximumScale() -> CGFloat {
         // maximum scale is fixed to 2.0 for now. This may be overriden to perform a more sophisticated computation
         return 2.0
     }
-    
-    fileprivate func setPictoCenter(){
+
+    fileprivate func setPictoCenter() {
         var intendHorizon = (screenSize().width - imageView.frame.width ) / 2
         var intendVertical = (screenSize().height - imageView.frame.height ) / 2
         intendHorizon = intendHorizon > 0 ? intendHorizon : 0
         intendVertical = intendVertical > 0 ? intendVertical : 0
         contentInset = UIEdgeInsets(top: intendVertical, left: intendHorizon, bottom: intendVertical, right: intendHorizon)
     }
-    
+
     private func isFullScreen() -> Bool {
         return imageView.frame.width >= screenSize().width && imageView.frame.height >= screenSize().height
     }
-    
+
     func clearContentInsets() {
         contentInset = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
     }
-    
+
     // MARK: UIScrollViewDelegate
-    
+
     open func scrollViewDidZoom(_ scrollView: UIScrollView) {
         setPictoCenter()
     }
-    
+
     open func viewForZooming(in scrollView: UIScrollView) -> UIView? {
-        return zoomEnabled ? imageView : nil;
+        return zoomEnabled ? imageView : nil
     }
-    
+
 }

--- a/ImageSlideshow/Classes/Core/InputSource.swift
+++ b/ImageSlideshow/Classes/Core/InputSource.swift
@@ -16,7 +16,7 @@ import UIKit
      - parameter callback: Callback called after the image was set to the image view.
      - parameter image: Image that was set to the image view.
      */
-    func load(to imageView: UIImageView, with callback: @escaping (_ image: UIImage) -> ())
+    func load(to imageView: UIImageView, with callback: @escaping (_ image: UIImage) -> Void)
 }
 
 /// Input Source to load plain UIImage
@@ -40,7 +40,7 @@ open class ImageSource: NSObject, InputSource {
         }
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> ()) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> Void) {
         imageView.image = image
         callback(image)
     }

--- a/ImageSlideshow/Classes/Core/UIImage+AspectFit.swift
+++ b/ImageSlideshow/Classes/Core/UIImage+AspectFit.swift
@@ -9,12 +9,12 @@
 import UIKit
 
 extension UIImage {
-    
+
     func tgr_aspectFitRectForSize(_ size: CGSize) -> CGRect {
         let targetAspect: CGFloat = size.width / size.height
         let sourceAspect: CGFloat = self.size.width / self.size.height
         var rect: CGRect = CGRect.zero
-        
+
         if targetAspect > sourceAspect {
             rect.size.height = size.height
             rect.size.width = ceil(rect.size.height * sourceAspect)
@@ -24,7 +24,7 @@ extension UIImage {
             rect.size.height = ceil(rect.size.width / sourceAspect)
             rect.origin.y = ceil((size.height - rect.size.height) * 0.5)
         }
-        
+
         return rect
     }
 }

--- a/ImageSlideshow/Classes/Core/UIImageView+Tools.swift
+++ b/ImageSlideshow/Classes/Core/UIImageView+Tools.swift
@@ -9,17 +9,17 @@
 import UIKit
 
 extension UIImageView {
-    
+
     func aspectToFitFrame() -> CGRect {
-        
+
         guard let image = image else {
             assertionFailure("No image found!")
             return CGRect.zero
         }
-        
+
         let imageRatio: CGFloat = image.size.width / image.size.height
         let viewRatio: CGFloat = frame.size.width / frame.size.height
-        
+
         if imageRatio < viewRatio {
             let scale: CGFloat = frame.size.height / image.size.height
             let width: CGFloat = scale * image.size.width

--- a/ImageSlideshow/Classes/InputSources/AFURLSource.swift
+++ b/ImageSlideshow/Classes/InputSources/AFURLSource.swift
@@ -39,7 +39,7 @@ public class AFURLSource: NSObject, InputSource {
         }
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> ()) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> Void) {
         imageView.setImageWith(URLRequest(url: url), placeholderImage: self.placeholder, success: { (_, _, image: UIImage) in
             imageView.image = image
             callback(image)

--- a/ImageSlideshow/Classes/InputSources/AlamofireSource.swift
+++ b/ImageSlideshow/Classes/InputSources/AlamofireSource.swift
@@ -31,7 +31,7 @@ public class AlamofireSource: NSObject, InputSource {
         }
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> ()) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> Void) {
         imageView.af_setImage(withURL: self.url, placeholderImage: nil, filter: nil, progress: nil) { (response) in
             imageView.image = response.result.value
             if let value = response.result.value {
@@ -39,5 +39,5 @@ public class AlamofireSource: NSObject, InputSource {
             }
         }
     }
-    
+
 }

--- a/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
+++ b/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
@@ -40,7 +40,7 @@ public class KingfisherSource: NSObject, InputSource {
         }
     }
 
-    @objc public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> ()) {
+    @objc public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> Void) {
         imageView.kf.setImage(with: self.url, placeholder: self.placeholder, options: nil, progressBlock: nil) { (image, _, _, _) in
             if let image = image {
                 callback(image)

--- a/ImageSlideshow/Classes/InputSources/SDWebImageSource.swift
+++ b/ImageSlideshow/Classes/InputSources/SDWebImageSource.swift
@@ -40,7 +40,7 @@ public class SDWebImageSource: NSObject, InputSource {
         }
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> ()) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage) -> Void) {
         imageView.sd_setImage(with: self.url, placeholderImage: self.placeholder, options: [], completed: { (image, _, _, _) in
             if let image = image {
                 callback(image)


### PR DESCRIPTION
Fix Trailing Whitespace
Fix Void Return
Fix Opening Brace Spacing
Fix Colon
Fix Trailing Semicolon
Fix Empty Parentheses with Trailing Closure
Fix Trailing Newline
Fix cocoapods ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES warning
Fix Unused Closure Parameter
Fix Control Statement Violation: if,for,while,do statements shouldn't wrap their conditionals in parentheses.
Fix Implicit Getter Violation: Computed read-only properties should avoid using the get keyword.
Remove some force casts. Force casts should be avoided.