### PR TITLE
Added ability to add a fallback image for all ImageSlideshowItem's

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -94,6 +94,9 @@ open class ImageSlideshow: UIView {
             return nil
         }
     }
+    
+    /// Optional fallbackImage for each InputSource
+    open var fallbackImage : ImageSource?
 
     /// Current scroll view page. This may differ from `currentPage` as circular slider has two more dummy pages at indexes 0 and n-1 to provide fluent scrolling between first and last item.
     open fileprivate(set) var scrollViewPage: Int = 0
@@ -245,7 +248,7 @@ open class ImageSlideshow: UIView {
 
         var i = 0
         for image in scrollViewImages {
-            let item = ImageSlideshowItem(image: image, zoomEnabled: self.zoomEnabled, activityIndicator: self.activityIndicator?.create())
+            let item = ImageSlideshowItem(image: image, zoomEnabled: self.zoomEnabled, activityIndicator: self.activityIndicator?.create(), fallbackImage: fallbackImage)
             item.imageView.contentMode = self.contentScaleMode
             slideshowItems.append(item)
             scrollView.addSubview(item)

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -18,6 +18,9 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
     /// Input Source for the item
     open let image: InputSource
+    
+    /// Fallback Input Source for the item
+    open let fallbackImage : InputSource?
 
     /// Guesture recognizer to detect double tap to zoom
     open var gestureRecognizer: UITapGestureRecognizer?
@@ -45,8 +48,9 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         Initializes a new ImageSlideshowItem
         - parameter image: Input Source to load the image
         - parameter zoomEnabled: holds if it should be possible to zoom-in the image
+        - parameter fallbackImage: A fallback image to display if image is unavailable
     */
-    init(image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil) {
+    init(image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil, fallbackImage: InputSource? = nil) {
         self.zoomEnabled = zoomEnabled
         self.image = image
         self.activityIndicator = activityIndicator
@@ -116,7 +120,8 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
     /// Request to load Image Source to Image View
     func loadImage() {
-        if self.imageView.image == nil && !isLoading {
+        if (self.imageView.image == nil || self.loadFailed) && !isLoading {
+            self.imageView.image = nil
             isLoading = true
             imageReleased = false
             activityIndicator?.show()
@@ -126,6 +131,11 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
                 self.activityIndicator?.hide()
                 self.loadFailed = image == nil
                 self.isLoading = false
+                if self.loadFailed && self.fallbackImage != nil {
+                    self.fallbackImage?.load(to: self.imageView) { fallbackImage in
+                        self.imageView.image = self.imageReleased ? nil : fallbackImage
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
I required a default/fallback image that will be used when the image load fails. 

This code allows the fallback image to be displayed whilst maintaining the reloading functionality etc. 