### PR TITLE
Allow passing KingfisherOptionsInfo for Kingfisher InputSource

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -17,19 +17,19 @@ PODS:
   - Alamofire (4.5.1)
   - AlamofireImage (3.3.0):
     - Alamofire (~> 4.5)
-  - ImageSlideshow (1.4.0):
-    - ImageSlideshow/Core (= 1.4.0)
-  - ImageSlideshow/AFURL (1.4.0):
+  - ImageSlideshow (1.4.1):
+    - ImageSlideshow/Core (= 1.4.1)
+  - ImageSlideshow/AFURL (1.4.1):
     - AFNetworking (~> 3.0)
     - ImageSlideshow/Core
-  - ImageSlideshow/Alamofire (1.4.0):
+  - ImageSlideshow/Alamofire (1.4.1):
     - AlamofireImage (~> 3.0)
     - ImageSlideshow/Core
-  - ImageSlideshow/Core (1.4.0)
-  - ImageSlideshow/Kingfisher (1.4.0):
+  - ImageSlideshow/Core (1.4.1)
+  - ImageSlideshow/Kingfisher (1.4.1):
     - ImageSlideshow/Core
     - Kingfisher (> 3.0)
-  - ImageSlideshow/SDWebImage (1.4.0):
+  - ImageSlideshow/SDWebImage (1.4.1):
     - ImageSlideshow/Core
     - SDWebImage (~> 3.7)
   - Kingfisher (4.0.1)
@@ -52,7 +52,7 @@ SPEC CHECKSUMS:
   AFNetworking: 5e0e199f73d8626b11e79750991f5d173d1f8b67
   Alamofire: 2d95912bf4c34f164fdfc335872e8c312acaea4a
   AlamofireImage: 2e784dc5d00f04903a52c1d169181469c805c3df
-  ImageSlideshow: e334e509ed959b22af649e2fd18c524a59f6b23c
+  ImageSlideshow: 8e7a03a73f6e87d2b7c8e42edb50430dc868f708
   Kingfisher: b771785e9461ed4b8686d40e7145f9e58100cb24
   SDWebImage: 098e97e6176540799c27e804c96653ee0833d13c
 

--- a/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
+++ b/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
@@ -15,23 +15,28 @@ public class KingfisherSource: NSObject, InputSource {
 
     /// placeholder used before image is loaded
     public var placeholder: UIImage?
+    
+    /// options for displaying, ie. [.transition(.fade(0.2))]
+    public var options: KingfisherOptionsInfo?
 
     /// Initializes a new source with a URL
     /// - parameter url: a url to be loaded
     /// - parameter placeholder: a placeholder used before image is loaded    
-    public init(url: URL, placeholder: UIImage? = nil) {
+    public init(url: URL, placeholder: UIImage? = nil, options: KingfisherOptionsInfo? = nil) {
         self.url = url
         self.placeholder = placeholder
+        self.options = options
         super.init()
     }
 
     /// Initializes a new source with a URL string
     /// - parameter urlString: a string url to load
     /// - parameter placeholder: a placeholder used before image is loaded
-    public init?(urlString: String, placeholder: UIImage? = nil) {
+    public init?(urlString: String, placeholder: UIImage? = nil, options: KingfisherOptionsInfo? = nil) {
         if let validUrl = URL(string: urlString) {
             self.url = validUrl
             self.placeholder = placeholder
+            self.options = options
             super.init()
         } else {
             return nil
@@ -39,7 +44,7 @@ public class KingfisherSource: NSObject, InputSource {
     }
 
     @objc public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
-        imageView.kf.setImage(with: self.url, placeholder: self.placeholder, options: nil, progressBlock: nil) { (image, _, _, _) in
+        imageView.kf.setImage(with: self.url, placeholder: self.placeholder, options: self.options, progressBlock: nil) { (image, _, _, _) in
             callback(image)
         }
     }


### PR DESCRIPTION
Great work! I had a need to pass display loading options for the Kingfisher InputSource so I've added that.

* Allow passing KingfisherOptionsInfo for Kingfisher InputSource
* Update pods in example.