### PR TITLE
allow SDWebImage 3.7 or any version newer, up to 5

### DIFF
--- a/ImageSlideshow.podspec
+++ b/ImageSlideshow.podspec
@@ -51,7 +51,7 @@ Image slideshow is a Swift library providing customizable image slideshow with c
 
   s.subspec 'SDWebImage' do |subspec|
     subspec.dependency 'ImageSlideshow/Core'
-    subspec.dependency 'SDWebImage', '~> 3.7'
+    subspec.dependency 'SDWebImage', '>= 3.7', '< 5.0'
     subspec.source_files = 'ImageSlideshow/Classes/InputSources/SDWebImageSource.swift'
   end
 


### PR DESCRIPTION
The latest release of SDWebImage is at 4.1.2, so we say <5 to note that this
library hasn't been tested against that major version (if and when it's
released).