### PR TITLE
Vertical scrolling is disabled in ImageSlideshow.swift

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -465,6 +465,10 @@ extension ImageSlideshow: UIScrollViewDelegate {
     open func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if circular {
             let regularContentOffset = scrollView.frame.size.width * CGFloat(images.count)
+            
+            if scrollView.contentOffset.y != 0 {
+                scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x, y: 0)
+            }
 
             if scrollView.contentOffset.x >= scrollView.frame.size.width * CGFloat(images.count + 1) {
                 scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x - regularContentOffset, y: 0)


### PR DESCRIPTION
I've noticed a small bug in vertical scrolling. 
When you place the view on top of the navigation bar, it starts scrolling vertically as well as horizontally. 
These lines of code will fix this issue. 