### PR TITLE
Fix missing placeholder on AFURLSource

### DIFF
--- a/ImageSlideshow/Classes/InputSources/AFURLSource.swift
+++ b/ImageSlideshow/Classes/InputSources/AFURLSource.swift
@@ -42,7 +42,7 @@ public class AFURLSource: NSObject, InputSource {
         imageView.setImageWith(URLRequest(url: url), placeholderImage: self.placeholder, success: { (_, _, image: UIImage) in
             callback(image)
         }, failure: { _, _, _ in
-            callback(nil)
+            callback(self.placeholder)
         })
     }
 }


### PR DESCRIPTION
In case AFURLSource can't load media, I reset the placeholder image in the failure callback.