### PR TITLE
Performance and zoom improvements

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -169,7 +169,22 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         if isZoomed() {
             self.setZoomScale(minimumZoomScale, animated: true)
         } else {
-            self.setZoomScale(maximumZoomScale, animated: true)
+            // Zoom to aspect fill the image
+            var scale = maximumZoomScale
+            if let image = self.imageView.image
+            {
+                let selfAspect = self.bounds.size.width / self.bounds.size.height
+                let imageAspect = image.size.width / image.size.height
+                if selfAspect > imageAspect
+                {
+                    scale = self.bounds.size.width / self.imageView.bounds.size.width
+                }
+                else
+                {
+                    scale = self.bounds.size.height / self.imageView.bounds.size.height
+                }
+            }
+            self.setZoomScale(min(scale, maximumZoomScale), animated: true)
         }
     }
 

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -135,6 +135,8 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
                 self?.activityIndicator?.hide()
                 self?.loadFailed = image == nil
                 self?.isLoading = false
+                
+                self?.setNeedsLayout()
             }
         }
     }

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -175,25 +175,6 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         return CGSize(width: frame.width, height: frame.height)
     }
 
-    fileprivate func calculatePictureFrame() {
-        let boundsSize: CGSize = bounds.size
-        var frameToCenter: CGRect = imageView.frame
-
-        if frameToCenter.size.width < boundsSize.width {
-            frameToCenter.origin.x = (boundsSize.width - frameToCenter.size.width) / 2
-        } else {
-            frameToCenter.origin.x = 0
-        }
-
-        if frameToCenter.size.height < boundsSize.height {
-            frameToCenter.origin.y = (boundsSize.height - frameToCenter.size.height) / 2
-        } else {
-            frameToCenter.origin.y = 0
-        }
-
-        imageView.frame = frameToCenter
-    }
-
     fileprivate func calculatePictureSize() -> CGSize {
         if let image = imageView.image, imageView.contentMode == .scaleAspectFit {
             let picSize = image.size

--- a/ImageSlideshow/Classes/Core/InputSource.swift
+++ b/ImageSlideshow/Classes/Core/InputSource.swift
@@ -36,16 +36,30 @@ open class ImageSource: NSObject, InputSource {
         self.image = image
     }
 
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+        imageView.image = image
+        callback(image)
+    }
+}
+
+/// Input Source to load an image from the main bundle
+@objcMembers
+open class BundleImageSource: NSObject, InputSource {
+    var imageString: String!
+    
     /// Initializes a new Image Source with an image name from the main bundle
     /// - parameter imageString: name of the file in the application's main bundle
-    public init?(imageString: String) {
-        if let image = UIImage(named: imageString) {
-            self.image = image
-            super.init()
-        } else {
-            return nil
-        }
+    public init(imageString: String) {
+        self.imageString = imageString
+        super.init()
     }
+    
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+        let image = UIImage(named: imageString)
+        imageView.image = image
+        callback(image)
+    }
+}
 
     public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
         imageView.image = image

--- a/ImageSlideshow/Classes/Core/InputSource.swift
+++ b/ImageSlideshow/Classes/Core/InputSource.swift
@@ -61,7 +61,20 @@ open class BundleImageSource: NSObject, InputSource {
     }
 }
 
+/// Input Source to load an image from a local file path
+@objcMembers
+open class FileImageSource: NSObject, InputSource {
+    var path: String!
+    
+    /// Initializes a new Image Source with an image name from the main bundle
+    /// - parameter imageString: name of the file in the application's main bundle
+    public init(path: String) {
+        self.path = path
+        super.init()
+    }
+    
     public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+        let image = UIImage(contentsOfFile: path)
         imageView.image = image
         callback(image)
     }


### PR DESCRIPTION
• New BundleImageSource class to load images lazily only on `load` function calls.
• New FileImageSource loads images from the local file system.
• Double tap now zooms to fill the `ImageSlideshow` view (screen). `maximumZoomScale` is still respected and can be set to a much higher scale to allow closely zooming images beyond what double tap would zoom.