### PR TITLE
fix for iOS 13

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -543,6 +543,8 @@ open class ImageSlideshow: UIView {
         fullscreen.inputs = images
         slideshowTransitioningDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: self, slideshowController: fullscreen)
         fullscreen.transitioningDelegate = slideshowTransitioningDelegate
+        fullscreen.modalPresentationStyle = .fullScreen
+        fullscreen.modalTransitionStyle = .coverVertical
         controller.present(fullscreen, animated: true, completion: nil)
 
         return fullscreen


### PR DESCRIPTION
With `Xcode 11 beta` running on `iOS 13` there are 2 issues:
- fullscreen animation is glitchy. it animates fullscreen, then reverts to the iOS 13 card style modal
- when swiping to dismiss or tapping the X to dismiss, the dismiss animates correctly, but when it's dismissed the presenting VC screen turns black blocking further use of the app.

These changes make sure that on iOS 13 iOS 12 style modal presentation is preserved solving both issues.

<img width="584" alt="Screenshot 2019-06-25 at 11 24 39" src="https://user-images.githubusercontent.com/1050853/60086705-ddb4f780-973b-11e9-821a-ca86666e56d0.png">
<img width="584" alt="Screenshot 2019-06-25 at 11 24 31" src="https://user-images.githubusercontent.com/1050853/60086706-ddb4f780-973b-11e9-9143-f8f5f62b81de.png">
 