### PR TITLE
Remove closure from FullScreenSlideShow.slideshow

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 @objcMembers
 open class FullScreenSlideshowViewController: UIViewController {
 
-    open var slideshow: ImageSlideshow = ImageSlideshow()
+    open var slideshow: ImageSlideshow!
     
 
     /// Close button 
@@ -44,6 +44,7 @@ open class FullScreenSlideshowViewController: UIViewController {
     */
     override open func loadView() {
         super.loadView()
+        slideshow = ImageSlideshow()
         slideshow.zoomEnabled = true
         slideshow.contentScaleMode = UIViewContentMode.scaleAspectFit
         slideshow.pageIndicatorPosition = PageIndicatorPosition(horizontal: .center, vertical: .bottom)

--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -20,7 +20,7 @@ open class FullScreenSlideshowViewController: UIViewController {
         slideshow.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
 
         return slideshow
-    }()
+    }
 
     /// Close button 
     open var closeButton = UIButton()

--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -10,17 +10,8 @@ import UIKit
 @objcMembers
 open class FullScreenSlideshowViewController: UIViewController {
 
-    open var slideshow: ImageSlideshow = {
-        let slideshow = ImageSlideshow()
-        slideshow.zoomEnabled = true
-        slideshow.contentScaleMode = UIViewContentMode.scaleAspectFit
-        slideshow.pageIndicatorPosition = PageIndicatorPosition(horizontal: .center, vertical: .bottom)
-        // turns off the timer
-        slideshow.slideshowInterval = 0
-        slideshow.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
-
-        return slideshow
-    }
+    open var slideshow: ImageSlideshow = ImageSlideshow()
+    
 
     /// Close button 
     open var closeButton = UIButton()
@@ -48,6 +39,18 @@ open class FullScreenSlideshowViewController: UIViewController {
     }
 
     fileprivate var isInit = true
+    /**
+     Default properties for the slideshow are set here.
+    */
+    override open func loadView() {
+        super.loadView()
+        slideshow.zoomEnabled = true
+        slideshow.contentScaleMode = UIViewContentMode.scaleAspectFit
+        slideshow.pageIndicatorPosition = PageIndicatorPosition(horizontal: .center, vertical: .bottom)
+        // turns off the timer
+        slideshow.slideshowInterval = 0
+        slideshow.autoresizingMask = [UIViewAutoresizing.flexibleWidth, UIViewAutoresizing.flexibleHeight]
+    }
 
     override open func viewDidLoad() {
         super.viewDidLoad()


### PR DESCRIPTION
Removed closure from 'slideshow' variable in FullScreenSlideShowViewController. Having this closure prevented ImageSlideshow from being used within a recycled view such as a CollectionViewCell because the fullscreen slideshow retained a reference to the first slide show loaded.