### PR TITLE
Accessibility enhancement #356

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -63,6 +63,11 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
         imageViewWrapper.addSubview(imageView)
         imageView.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        imageView.isAccessibilityElement = true
+        imageView.accessibilityTraits = .image
+        if #available(iOS 11.0, *) {
+            imageView.accessibilityIgnoresInvertColors = true
+        }
 
         imageViewWrapper.clipsToBounds = true
         imageViewWrapper.isUserInteractionEnabled = true


### PR DESCRIPTION
Mark items in the image carousel as accessibilityElements and add the accessibilityTrait .image. This allows blind users to ask the system to attempt to describe what is shown but at the very least lets people know that the picker (which is supported by VoiceOver) is in fact changing something (currently the images aren't selectable by Voiceover).

Mark images in the carousel's accessibilityIgnoresInvertColors property to true so they don't invert when smart invert is enabled! People using this setting expect most things to invert but not images which then become pretty weird looking.