### PR TITLE
Use imageViewProvider to create imageView

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -214,6 +214,11 @@ open class ImageSlideshow: UIView {
         return scrollView.frame.size.width > 0 ? Int(scrollView.contentOffset.x + scrollView.frame.size.width / 2) / Int(scrollView.frame.size.width) : 0
     }
 
+    /// Provider that creates UIImageView for each slideshow item. By default just returns UIImageView().
+    open var imageViewProvider: () -> UIImageView = {
+        return UIImageView()
+    }
+
     // MARK: - Life cycle
 
     override public init(frame: CGRect) {
@@ -320,7 +325,13 @@ open class ImageSlideshow: UIView {
 
         var i = 0
         for image in scrollViewImages {
-            let item = ImageSlideshowItem(image: image, zoomEnabled: zoomEnabled, activityIndicator: activityIndicator?.create(), maximumScale: maximumScale)
+            let item = ImageSlideshowItem(
+                imageView: imageViewProvider(),
+                image: image,
+                zoomEnabled: zoomEnabled,
+                activityIndicator: activityIndicator?.create(),
+                maximumScale: maximumScale
+            )
             item.imageView.contentMode = contentScaleMode
             slideshowItems.append(item)
             scrollView.addSubview(item)

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -12,7 +12,7 @@ import UIKit
 open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
     /// Image view to hold the image
-    public let imageView = UIImageView()
+    public let imageView: UIImageView
 
     /// Activity indicator shown during image loading, when nil there won't be shown any
     public let activityIndicator: ActivityIndicatorView?
@@ -53,7 +53,8 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         - parameter image: Input Source to load the image
         - parameter zoomEnabled: holds if it should be possible to zoom-in the image
     */
-    init(image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil, maximumScale: CGFloat = 2.0) {
+    init(imageView: UIImageView, image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil, maximumScale: CGFloat = 2.0) {
+        self.imageView = imageView
         self.zoomEnabled = zoomEnabled
         self.image = image
         self.activityIndicator = activityIndicator


### PR DESCRIPTION
#### Motivation:
In some cases, I want to use a UIImageView's subclass in slideshow. For example, to display animations using `FLAnimatedImage`.

#### How to use:
```swift
let slideshow = ImageSlideshow()
slideshow.imageViewProvider = { FLAnimatedImageView() }
```