### PR TITLE
Feature/371 updating alamofireimage

### DIFF
--- a/ImageSlideshow.podspec
+++ b/ImageSlideshow.podspec
@@ -44,7 +44,7 @@ Image slideshow is a Swift library providing customizable image slideshow with c
 
   s.subspec 'Alamofire' do |subspec|
     subspec.dependency 'ImageSlideshow/Core'
-    subspec.dependency 'AlamofireImage', '~> 3.0'
+    subspec.dependency 'AlamofireImage', '~> 4.0'
     subspec.source_files = 'ImageSlideshow/Classes/InputSources/AlamofireSource.swift'
   end
 

--- a/ImageSlideshow.podspec
+++ b/ImageSlideshow.podspec
@@ -28,7 +28,7 @@ Image slideshow is a Swift library providing customizable image slideshow with c
   s.social_media_url = 'https://twitter.com/zvonicek'
 
   s.swift_versions = ['4.0', '4.1', '4.2', '5', '5.1']
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '10.0'
   s.requires_arc = true
 
   s.subspec 'Core' do |core|

--- a/ImageSlideshow/Classes/InputSources/AlamofireSource.swift
+++ b/ImageSlideshow/Classes/InputSources/AlamofireSource.swift
@@ -45,7 +45,7 @@ public class AlamofireSource: NSObject, InputSource {
     }
 
     public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
-        imageView.af_setImage(withURL: self.url, placeholderImage: placeholder, filter: nil, progress: nil) { [weak self] (response) in                                                              
+        imageView.af.setImage(withURL: self.url, placeholderImage: placeholder, filter: nil, progress: nil) { [weak self] (response) in
             switch response.result {
             case .success(let image):
                 callback(image)
@@ -60,6 +60,6 @@ public class AlamofireSource: NSObject, InputSource {
     }
 
     public func cancelLoad(on imageView: UIImageView) {
-        imageView.af_cancelImageRequest()
+        imageView.af.cancelImageRequest()
     }
 }


### PR DESCRIPTION
This updates AlamofireImage. 
Two breaking changes:
 * projects that are using older versions of AlamofireImage will have to update AlamofireImage to use the version of ImageSlideshow this change is included in.
* platform in podspec set to 10.0