### PR TITLE
Fix PageControl flicker

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -114,6 +114,7 @@ open class ImageSlideshow: UIView {
     open fileprivate(set) var currentPage: Int = 0 {
         didSet {
             if oldValue != currentPage {
+                pageIndicator?.page = currentPage
                 currentPageChanged?(currentPage)
                 delegate?.imageSlideshow?(self, didChangeCurrentPageTo: currentPage)
             }
@@ -583,8 +584,6 @@ extension ImageSlideshow: UIScrollViewDelegate {
                 scrollView.contentOffset = CGPoint(x: scrollView.contentOffset.x + regularContentOffset, y: 0)
             }
         }
-
-        pageIndicator?.page = currentPageForScrollViewPage(primaryVisiblePage)
     }
 
     public func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {


### PR DESCRIPTION
When tapping on the page control to switch images, the page control first updates to its new index. Then the page control reports its value changed, which ImageSlideshow listens to and subsequently calls
```
        if let currentPage = pageIndicator?.page {
            setCurrentPage(currentPage, animated: true)
        }
```

Because animated is true, the scrollViewDidScroll delegate method is called. This method updates the page control's index, but as the scroll view starts to scroll, the page control's index will switch back to its original index, until the start image is mostly animated away.

This causes a jarring flicker effect.

The correct behavior is to keep the page control's page in sync with ImageSlideshow.currentPage. This fixes the flicker and results in the same behavior as Apple's springboard.