### PR TITLE
Listen for page control changes by default on explicitly set page con…

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -79,6 +79,9 @@ open class ImageSlideshow: UIView {
             oldValue?.view.removeFromSuperview()
             if let pageIndicator = pageIndicator {
                 addSubview(pageIndicator.view)
+                if let pageIndicator = pageIndicator as? UIControl {
+                    pageIndicator.addTarget(self, action: #selector(pageControlValueChanged), for: .valueChanged)
+                }
             }
             setNeedsLayout()
         }


### PR DESCRIPTION
…trols

Technically, this would be a breaking change as current implementations don't expect ImageSlideshow to listen for `.valueChanged` on a PageControl they set themselves. That said, this would be a nice addition so that users of ImageSlideshow don't have to implement this logic themselves.