### PR TITLE
Replace close button image with xmark SF Symbol in iOS 13

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -72,7 +72,12 @@ open class FullScreenSlideshowViewController: UIViewController {
         view.addSubview(slideshow)
 
         // close button configuration
-        closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        if #available(iOS 13.0, *) {
+            closeButton.setImage(UIImage(systemName: "xmark"), for: UIControl.State())
+            closeButton.tintColor = .white
+        } else {
+            closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        }
         closeButton.addTarget(self, action: #selector(FullScreenSlideshowViewController.close), for: UIControlEvents.touchUpInside)
         view.addSubview(closeButton)
     }


### PR DESCRIPTION
For #362

If cloning the repository using Swift Package Manager, the close button image is not downloaded. This replaces the button's image with the `xmark` SF Symbol if the device is running iOS 13 or newer.