### PR TITLE
Allow the initial page to be specified when setting image inputs

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -72,7 +72,12 @@ open class FullScreenSlideshowViewController: UIViewController {
         view.addSubview(slideshow)
 
         // close button configuration
-        closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        if #available(iOS 13.0, *) {
+            closeButton.setImage(UIImage(systemName: "xmark"), for: UIControl.State())
+            closeButton.tintColor = .white
+        } else {
+            closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        }
         closeButton.addTarget(self, action: #selector(FullScreenSlideshowViewController.close), for: UIControlEvents.touchUpInside)
         view.addSubview(closeButton)
     }

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -311,7 +311,7 @@ open class ImageSlideshow: UIView {
     }
 
     /// reloads scroll view with latest slideshow items
-    func reloadScrollView() {
+    func reloadScrollView(initialPage: Int = 0) {
         // remove previous slideshow items
         for view in slideshowItems {
             view.removeFromSuperview()
@@ -328,10 +328,10 @@ open class ImageSlideshow: UIView {
         }
 
         if circular && (scrollViewImages.count > 1) {
-            scrollViewPage = 1
+            scrollViewPage = initialPage + 1
             scrollView.scrollRectToVisible(CGRect(x: scrollView.frame.size.width, y: 0, width: scrollView.frame.size.width, height: scrollView.frame.size.height), animated: false)
         } else {
-            scrollViewPage = 0
+            scrollViewPage = initialPage
         }
 
         loadImages(for: scrollViewPage)
@@ -362,7 +362,7 @@ open class ImageSlideshow: UIView {
      Set image inputs into the image slideshow
      - parameter inputs: Array of InputSource instances.
      */
-    open func setImageInputs(_ inputs: [InputSource]) {
+    open func setImageInputs(_ inputs: [InputSource], initialPage: Int = 0) {
         images = inputs
         pageIndicator?.numberOfPages = inputs.count
 
@@ -383,7 +383,7 @@ open class ImageSlideshow: UIView {
             scrollViewImages = images
         }
 
-        reloadScrollView()
+        reloadScrollView(initialPage: initialPage)
         layoutScrollView()
         layoutPageControl()
         setTimerIfNeeded()


### PR DESCRIPTION
Add `initialPage: Int` argument to `setImageInputs` and `reloadScrollView`.

This allows the image inputs to be changed after initialization while keeping position in the slideshow. For example, if the user gets toward the end of the slideshow, the app could load `n` more images, append them to the Image Inputs, unload `n` images from the beginning, then reload the inputs with `setImageInputs`, setting the `initialPage` to the current page minus `n`. This would allow the user to stay on the same image while having fewer images loaded, using less memory.

Also includes #385