### PR TITLE
fixed slideshowTransition bug

### DIFF
--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -212,7 +212,7 @@ open class ImageSlideshow: UIView {
     fileprivate var isAnimating: Bool = false
 
     /// Transitioning delegate to manage the transition to full screen controller
-    open fileprivate(set) weak var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate?
+    open fileprivate(set) var slideshowTransitioningDelegate: ZoomAnimatedTransitioningDelegate? // swiftlint:disable:this weak_delegate
 
     private var primaryVisiblePage: Int {
         return scrollView.frame.size.width > 0 ? Int(scrollView.contentOffset.x + scrollView.frame.size.width / 2) / Int(scrollView.frame.size.width) : 0


### PR DESCRIPTION
I think you use swiftLint, which automatically has added "weak" to the zoomAnimatedTransitioningDelegate, but ZoomAnimatedTransitioningDelegate is a class, not a protocol and it is not working.