### PR TITLE
add caption support on both normal and fullscreen controller

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -13,6 +13,7 @@ open class FullScreenSlideshowViewController: UIViewController {
     open var slideshow: ImageSlideshow = {
         let slideshow = ImageSlideshow()
         slideshow.zoomEnabled = true
+        slideshow.isFullScreenSlideShow = true
         slideshow.contentScaleMode = UIViewContentMode.scaleAspectFit
         slideshow.pageIndicatorPosition = PageIndicatorPosition(horizontal: .center, vertical: .bottom)
         // turns off the timer

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -164,6 +164,13 @@ open class ImageSlideshow: UIView {
             }
         }
     }
+    
+    /// isFullScreenSlideShow handle fullscreen
+    open var isFullScreenSlideShow = false {
+        didSet {
+            reloadScrollView()
+        }
+    }
 
     /// Enables/disables user interactions
     open var draggingEnabled = true {
@@ -320,7 +327,7 @@ open class ImageSlideshow: UIView {
 
         var i = 0
         for image in scrollViewImages {
-            let item = ImageSlideshowItem(image: image, zoomEnabled: zoomEnabled, activityIndicator: activityIndicator?.create(), maximumScale: maximumScale)
+            let item = ImageSlideshowItem(image: image, zoomEnabled: zoomEnabled, activityIndicator: activityIndicator?.create(), maximumScale: maximumScale, isFullScreenSlideShow: isFullScreenSlideShow)
             item.imageView.contentMode = contentScaleMode
             slideshowItems.append(item)
             scrollView.addSubview(item)

--- a/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshowItem.swift
@@ -14,6 +14,15 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
     /// Image view to hold the image
     public let imageView = UIImageView()
 
+    /// Caption Label to show image caption
+    public let captionLabel = UILabel()
+    
+    /// Caption Container that add caption and background color
+    fileprivate var captionContainerView: UIView
+    
+    /// isFullScreenSlideShow ture if slider full screen controller shown
+    public let isFullScreenSlideShow: Bool
+
     /// Activity indicator shown during image loading, when nil there won't be shown any
     public let activityIndicator: ActivityIndicatorView?
 
@@ -53,12 +62,25 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         - parameter image: Input Source to load the image
         - parameter zoomEnabled: holds if it should be possible to zoom-in the image
     */
-    init(image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil, maximumScale: CGFloat = 2.0) {
+    init(image: InputSource, zoomEnabled: Bool, activityIndicator: ActivityIndicatorView? = nil, maximumScale: CGFloat = 2.0, isFullScreenSlideShow: Bool) {
         self.zoomEnabled = zoomEnabled
         self.image = image
         self.activityIndicator = activityIndicator
         self.maximumScale = maximumScale
-
+        self.isFullScreenSlideShow = isFullScreenSlideShow
+        
+        let captionConstraintView = UIView()
+        captionConstraintView.addSubview(captionLabel)
+        if #available(iOS 9.0, *) {
+            let captionStackView = UIStackView()
+            captionStackView.axis = .vertical
+            captionStackView.alignment = .leading
+            captionStackView.addArrangedSubview(captionConstraintView)
+            captionContainerView = captionStackView
+        } else {
+            captionContainerView = captionConstraintView
+        }
+        
         super.init(frame: CGRect.null)
 
         imageViewWrapper.addSubview(imageView)
@@ -69,7 +91,8 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
             imageView.accessibilityIgnoresInvertColors = true
         }
 
-        imageViewWrapper.clipsToBounds = true
+        // clips to bounds false if fullscreen so we can show caption outside image
+        imageViewWrapper.clipsToBounds = !isFullScreenSlideShow
         imageViewWrapper.isUserInteractionEnabled = true
         if UIApplication.shared.userInterfaceLayoutDirection == .rightToLeft {
             imageView.transform = CGAffineTransform(rotationAngle: CGFloat(Double.pi))
@@ -99,6 +122,22 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
         singleTapGestureRecognizer!.numberOfTapsRequired = 1
         singleTapGestureRecognizer!.isEnabled = false
         imageViewWrapper.addGestureRecognizer(singleTapGestureRecognizer!)
+        
+        captionContainerView.addSubview(captionConstraintView)
+        imageViewWrapper.addSubview(captionContainerView)
+        captionLabel.textColor = .white
+        captionLabel.numberOfLines = 0
+        captionConstraintView.backgroundColor = UIColor.black.withAlphaComponent(0.5)
+        captionLabel.translatesAutoresizingMaskIntoConstraints = false
+        captionContainerView.translatesAutoresizingMaskIntoConstraints = false
+        
+        let leadingConstraint = NSLayoutConstraint(item: captionLabel, attribute: NSLayoutConstraint.Attribute.leading, relatedBy: NSLayoutConstraint.Relation.equal, toItem: captionConstraintView, attribute: NSLayoutConstraint.Attribute.leading, multiplier: 1, constant: 5)
+        let trailingConstraint = NSLayoutConstraint(item: captionLabel, attribute: NSLayoutConstraint.Attribute.trailing, relatedBy: NSLayoutConstraint.Relation.equal, toItem: captionConstraintView, attribute: NSLayoutConstraint.Attribute.trailing, multiplier: 1, constant: -5)
+        let topConstraint = NSLayoutConstraint(item: captionLabel, attribute: NSLayoutConstraint.Attribute.top, relatedBy: NSLayoutConstraint.Relation.equal, toItem: captionConstraintView, attribute: NSLayoutConstraint.Attribute.top, multiplier: 1, constant: 5)
+        let bottomConstraint = NSLayoutConstraint(item: captionLabel, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: captionConstraintView, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1, constant: -5)
+        
+        NSLayoutConstraint.activate([topConstraint, leadingConstraint, bottomConstraint, trailingConstraint,])
+
     }
 
     required public init?(coder aDecoder: NSCoder) {
@@ -131,6 +170,10 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
 
         contentSize = imageViewWrapper.frame.size
         maximumZoomScale = calculateMaximumScale()
+        
+        let leadingConstraint = NSLayoutConstraint(item: captionContainerView, attribute: NSLayoutConstraint.Attribute.leading, relatedBy: NSLayoutConstraint.Relation.equal, toItem: imageViewWrapper, attribute: NSLayoutConstraint.Attribute.leading, multiplier: 1, constant: 20)
+        let trailingConstraint = NSLayoutConstraint(item: captionContainerView, attribute: NSLayoutConstraint.Attribute.trailing, relatedBy: NSLayoutConstraint.Relation.equal, toItem: imageViewWrapper, attribute: NSLayoutConstraint.Attribute.trailing, multiplier: 1, constant: -20)
+        NSLayoutConstraint.activate([leadingConstraint, trailingConstraint,])
     }
 
     /// Request to load Image Source to Image View
@@ -139,18 +182,24 @@ open class ImageSlideshowItem: UIScrollView, UIScrollViewDelegate {
             isLoading = true
             imageReleased = false
             activityIndicator?.show()
-            image.load(to: self.imageView) {[weak self] image in
+            image.load(to: self.imageView) {[weak self] (image, caption, captionBottomConstraint, showCaptionOnlyInFullScreen)  in
+                guard let self = self else { return }
                 // set image to nil if there was a release request during the image load
-                if let imageRelease = self?.imageReleased, imageRelease {
-                    self?.imageView.image = nil
+                if self.imageReleased {
+                    self.imageView.image = nil
                 } else {
-                    self?.imageView.image = image
+                    self.imageView.image = image
                 }
-                self?.activityIndicator?.hide()
-                self?.loadFailed = image == nil
-                self?.isLoading = false
+                self.captionLabel.text = caption
+                self.captionContainerView.isHidden = (!self.isFullScreenSlideShow && showCaptionOnlyInFullScreen) || (caption ?? "").isEmpty
+                
+                NSLayoutConstraint(item: self.captionContainerView, attribute: NSLayoutConstraint.Attribute.bottom, relatedBy: NSLayoutConstraint.Relation.equal, toItem: self.imageViewWrapper, attribute: NSLayoutConstraint.Attribute.bottom, multiplier: 1, constant: captionBottomConstraint).isActive = true
+                
+                self.activityIndicator?.hide()
+                self.loadFailed = image == nil
+                self.isLoading = false
 
-                self?.setNeedsLayout()
+                self.setNeedsLayout()
             }
         }
     }

--- a/ImageSlideshow/Classes/Core/InputSource.swift
+++ b/ImageSlideshow/Classes/Core/InputSource.swift
@@ -16,7 +16,7 @@ import UIKit
      - parameter callback: Callback called after image was set to the image view.
      - parameter image: Image that was set to the image view.
      */
-    func load(to imageView: UIImageView, with callback: @escaping (_ image: UIImage?) -> Void)
+    func load(to imageView: UIImageView, with callback: @escaping (_ image: UIImage?, _ caption: String?, _ captionBottomConstraint: CGFloat, _ showCaptionOnlyInFullScreen: Bool) -> Void)
 
     /**
      Cancel image load on the image view
@@ -29,28 +29,37 @@ import UIKit
 @objcMembers
 open class ImageSource: NSObject, InputSource {
     var image: UIImage
+    var caption: String
+    var captionBottomConstraint: CGFloat
+    var showCaptionOnlyInFullScreen: Bool
 
     /// Initializes a new Image Source with UIImage
     /// - parameter image: Image to be loaded
-    public init(image: UIImage) {
+    public init(image: UIImage, caption: String = "", captionBottomConstraint: CGFloat = 0, showCaptionOnlyInFullScreen: Bool = false) {
         self.image = image
+        self.caption = caption
+        self.captionBottomConstraint = captionBottomConstraint
+        self.showCaptionOnlyInFullScreen = showCaptionOnlyInFullScreen
     }
 
     /// Initializes a new Image Source with an image name from the main bundle
     /// - parameter imageString: name of the file in the application's main bundle
     @available(*, deprecated, message: "Use `BundleImageSource` instead")
-    public init?(imageString: String) {
+    public init?(imageString: String, caption: String = "", captionBottomConstraint: CGFloat = 0, showCaptionOnlyInFullScreen: Bool = false) {
         if let image = UIImage(named: imageString) {
             self.image = image
+            self.caption = caption
+            self.captionBottomConstraint = captionBottomConstraint
+            self.showCaptionOnlyInFullScreen = showCaptionOnlyInFullScreen
             super.init()
         } else {
             return nil
         }
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?, String?, CGFloat, Bool) -> Void) {
         imageView.image = image
-        callback(image)
+        callback(image, caption, captionBottomConstraint, showCaptionOnlyInFullScreen)
     }
 }
 
@@ -58,18 +67,25 @@ open class ImageSource: NSObject, InputSource {
 @objcMembers
 open class BundleImageSource: NSObject, InputSource {
     var imageString: String
+    var caption: String
+    var captionBottomConstraint: CGFloat
+    var showCaptionOnlyInFullScreen: Bool
 
     /// Initializes a new Image Source with an image name from the main bundle
     /// - parameter imageString: name of the file in the application's main bundle
-    public init(imageString: String) {
+    public init(imageString: String, caption: String = "", captionBottomConstraint: CGFloat = 0, showCaptionOnlyInFullScreen: Bool = false) {
         self.imageString = imageString
+        self.caption = caption
+        self.captionBottomConstraint = captionBottomConstraint
+        self.showCaptionOnlyInFullScreen = showCaptionOnlyInFullScreen
+
         super.init()
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?, String?, CGFloat, Bool) -> Void) {
         let image = UIImage(named: imageString)
         imageView.image = image
-        callback(image)
+        callback(image, caption, captionBottomConstraint, showCaptionOnlyInFullScreen)
     }
 }
 
@@ -77,17 +93,24 @@ open class BundleImageSource: NSObject, InputSource {
 @objcMembers
 open class FileImageSource: NSObject, InputSource {
     var path: String
+    var caption: String
+    var captionBottomConstraint: CGFloat
+    var showCaptionOnlyInFullScreen: Bool
 
     /// Initializes a new Image Source with an image name from the main bundle
     /// - parameter imageString: name of the file in the application's main bundle
-    public init(path: String) {
+    public init(path: String, caption: String = "", captionBottomConstraint: CGFloat = 0, showCaptionOnlyInFullScreen: Bool = false) {
         self.path = path
+        self.caption = caption
+        self.captionBottomConstraint = captionBottomConstraint
+        self.showCaptionOnlyInFullScreen = showCaptionOnlyInFullScreen
+
         super.init()
     }
 
-    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?) -> Void) {
+    public func load(to imageView: UIImageView, with callback: @escaping (UIImage?, String?, CGFloat, Bool) -> Void) {
         let image = UIImage(contentsOfFile: path)
         imageView.image = image
-        callback(image)
+        callback(image, caption, captionBottomConstraint, showCaptionOnlyInFullScreen)
     }
 }


### PR DESCRIPTION
Hi I add the caption support for both normal and fullscreen controller with option caption only can be shown only for fullscreen if you wan't.
![Simulator Screen Shot - iPad Pro (11-inch) (2nd generation) - 2020-07-29 at 16 07 58](https://user-images.githubusercontent.com/60219366/88793185-dd482500-d1b5-11ea-8f87-35c110244ab6.png)
