### PR TITLE
Pass along preload parameters to fullscreen slideshow

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -34,6 +34,9 @@ open class FullScreenSlideshowViewController: UIViewController {
     /// Index of initial image
     open var initialPage: Int = 0
 
+    /// Number of images to preload
+    open var preload: ImagePreload?
+    
     /// Input sources to 
     open var inputs: [InputSource]?
 
@@ -65,6 +68,10 @@ open class FullScreenSlideshowViewController: UIViewController {
         view.backgroundColor = backgroundColor
         slideshow.backgroundColor = backgroundColor
 
+        if let preload = preload {
+            slideshow.preload = preload
+        }
+        
         if let inputs = inputs {
             slideshow.setImageInputs(inputs)
         }

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -544,6 +544,7 @@ open class ImageSlideshow: UIView {
         }
 
         fullscreen.initialPage = currentPage
+        fullscreen.preload = preload
         fullscreen.inputs = images
         slideshowTransitioningDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: self, slideshowController: fullscreen)
         fullscreen.transitioningDelegate = slideshowTransitioningDelegate


### PR DESCRIPTION
This PR passes along any default `preload` settings defined for the slideshow in the main view controller to the slideshow instantiated by the fullscreen view controller.