### PR TITLE
Add optional property for defining a custom fullscreen close button.

### DIFF
--- a/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
+++ b/ImageSlideshow/Classes/Core/FullScreenSlideshowViewController.swift
@@ -25,6 +25,9 @@ open class FullScreenSlideshowViewController: UIViewController {
     /// Close button 
     open var closeButton = UIButton()
 
+    /// Custom close button
+    open var closeButtonCustom: UIButton?
+    
     /// Close button frame
     open var closeButtonFrame: CGRect?
 
@@ -71,8 +74,13 @@ open class FullScreenSlideshowViewController: UIViewController {
 
         view.addSubview(slideshow)
 
-        // close button configuration
-        closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        if closeButtonCustom != nil {
+            closeButton = closeButtonCustom!
+        } else {
+            // close button configuration
+            closeButton.setImage(UIImage(named: "ic_cross_white", in: Bundle(for: type(of: self)), compatibleWith: nil), for: UIControlState())
+        }
+        
         closeButton.addTarget(self, action: #selector(FullScreenSlideshowViewController.close), for: UIControlEvents.touchUpInside)
         view.addSubview(closeButton)
     }

--- a/ImageSlideshow/Classes/Core/ImageSlideshow.swift
+++ b/ImageSlideshow/Classes/Core/ImageSlideshow.swift
@@ -136,6 +136,9 @@ open class ImageSlideshow: UIView {
     /// Called on scrollViewDidEndDecelerating
     open var didEndDecelerating: (() -> Void)?
 
+    /// Custom fullscreen close button
+    open var fullscreenCloseButton: UIButton?
+    
     /// Currenlty displayed slideshow item
     open var currentSlideshowItem: ImageSlideshowItem? {
         if slideshowItems.count > scrollViewPage {
@@ -543,6 +546,7 @@ open class ImageSlideshow: UIView {
             self?.setCurrentPage(page, animated: false)
         }
 
+        fullscreen.closeButtonCustom = fullscreenCloseButton
         fullscreen.initialPage = currentPage
         fullscreen.inputs = images
         slideshowTransitioningDelegate = ZoomAnimatedTransitioningDelegate(slideshowView: self, slideshowController: fullscreen)


### PR DESCRIPTION
This PR tries to build on https://github.com/zvonicek/ImageSlideshow/pull/385 but rather than defining new presets allows for a consume of the `ImageSlideshow` package to define a custom `UIButton` to use for ending fullscreen mode.

The button is assigned to the slideshow's `fullscreenCloseButton` property which is then assigned to the FullScreenSlideshowViewController's `closeButtonCustom` property. For example:

```
        let closeButton = UIButton()
        closeButton.setImage(UIImage(systemName: "xmark"), for: UIControl.State())
        closeButton.tintColor = .white
        
        slideshow.fullscreenCloseButton = closeButton
```