### PR TITLE
Update KingfisherSource.swift

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ImageSlideshow/Classes/Core/ZoomAnimatedTransitioning.swift
+++ b/ImageSlideshow/Classes/Core/ZoomAnimatedTransitioning.swift
@@ -62,11 +62,11 @@ open class ZoomAnimatedTransitioningDelegate: NSObject, UIViewControllerTransiti
     }
 
     func handleSwipe(_ gesture: UIPanGestureRecognizer) {
-        guard let referenceSlideshowController = referenceSlideshowController else {
+        guard let referenceSlideshowController = referenceSlideshowController, let view = gesture.view else {
             return
         }
 
-        let percent = min(max(abs(gesture.translation(in: gesture.view!).y) / 200.0, 0.0), 1.0)
+        let percent = min(max(abs(gesture.translation(in: view).y) / 200.0, 0.0), 1.0)
 
         if gesture.state == .began {
             interactionController = UIPercentDrivenInteractiveTransition()

--- a/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
+++ b/ImageSlideshow/Classes/InputSources/KingfisherSource.swift
@@ -61,7 +61,18 @@ public class KingfisherSource: NSObject, InputSource {
             case .success(let image):
                 callback(image.image)
             case .failure:
-                callback(self.placeholder)
+                var failureImage: UIImage?
+                
+                for option in self.options ?? [] {
+                    switch option {
+                    case .onFailureImage(let image):
+                        failureImage = image
+                    default:
+                        continue
+                    }
+                }
+                
+                callback(failureImage ?? self.placeholder)
             }
         }
     }

--- a/Package.resolved
+++ b/Package.resolved
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/onevcat/Kingfisher.git",
         "state": {
           "branch": null,
-          "revision": "349ed06467a6f8a4939bcb83db301542bc84eac9",
-          "version": "5.13.4"
+          "revision": "b6f62758f21a8c03cd64f4009c037cfa580a256e",
+          "version": "7.9.1"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             targets: ["ImageSlideshowKingfisher"])
     ],
     dependencies: [
-        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "5.8.0"),
+        .package(url: "https://github.com/onevcat/Kingfisher.git", from: "7.9.1"),
         .package(url: "https://github.com/Alamofire/AlamofireImage.git", from: "4.0.0"),
         .package(url: "https://github.com/SDWebImage/SDWebImage.git", from: "5.1.0")
     ],


### PR DESCRIPTION
onFailureImage option doesn't work fixed. We couldn't use `.onFailureImage()` option on KingFisherSource.